### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/botModules.py
+++ b/botModules.py
@@ -9,7 +9,7 @@ import urllib.parse
 import urllib.request
 
 import requests
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 
 class botModules:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ Django==2.2.5
 gunicorn==19.9.0
 psycopg2==2.8.3
 whitenoise==4.1.3
-fuzzywuzzy[speedup]==0.17.0
+rapidfuzz==0.9.1
 requests>=2.20.0
 twython==3.7.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy